### PR TITLE
fix: impression

### DIFF
--- a/ios/BebitTechReactNativeAppSdk.swift
+++ b/ios/BebitTechReactNativeAppSdk.swift
@@ -72,8 +72,8 @@ class BebitTechReactNativeAppSdk: NSObject {
               event_action = eventAction
               print("Send event_action? : \(event_action)")
           } else {
-            print("Missing event_action key")
-            event_action = ""
+              event_action = ""
+              print("Impression event sent without event_action")
           }
 
           let event = OSGEvent.custom(action: event_action)

--- a/ios/BebitTechReactNativeAppSdk.swift
+++ b/ios/BebitTechReactNativeAppSdk.swift
@@ -69,11 +69,13 @@ class BebitTechReactNativeAppSdk: NSObject {
 
           let event_action: String
           if let eventAction = eventJson["event_action"] as? String {
-             event_action = eventAction
+              event_action = eventAction
+              print("Send event_action? : \(event_action)")
           } else {
             print("Missing event_action key")
-            return
+            event_action = ""
           }
+
           let event = OSGEvent.custom(action: event_action)
           event.appendAttributes(eventJson)
           OmniSegment.trackEvent(event)


### PR DESCRIPTION
問題描述:在 React Native 的 iOS 上,若 impression 缺少 event_action 時,會直接被 return,導致 product impression 無法送出。
修正方式:移除提前返回(early return)的程式碼。

測試方式:在原生(native)與網頁(webview)頁面中,測試所有觸發類型的彈出視窗(popup)是否均能正常顯示。
